### PR TITLE
add additional comments in header of file

### DIFF
--- a/tests/expected_results/extra_comment/v1/input.py
+++ b/tests/expected_results/extra_comment/v1/input.py
@@ -1,0 +1,9 @@
+from pydantic import BaseModel, Extra
+
+
+class ModelAllow(BaseModel, extra=Extra.allow):
+    a: str
+
+
+class ModelDefault(BaseModel):
+    a: str

--- a/tests/expected_results/extra_comment/v1/output.ts
+++ b/tests/expected_results/extra_comment/v1/output.ts
@@ -1,0 +1,15 @@
+/* tslint:disable */
+/* eslint-disable */
+/**
+/* This file was automatically generated from pydantic models by running pydantic2ts.
+/* Do not modify it by hand - just update the pydantic models and then re-run the script
+/* This is a special comment
+*/
+
+export interface ModelAllow {
+  a: string;
+  [k: string]: unknown;
+}
+export interface ModelDefault {
+  a: string;
+}

--- a/tests/expected_results/extra_comment/v2/input.py
+++ b/tests/expected_results/extra_comment/v2/input.py
@@ -1,0 +1,20 @@
+from pydantic import BaseModel, ConfigDict
+
+
+class ModelExtraAllow(BaseModel):
+    model_config = ConfigDict(extra="allow")
+    a: str
+
+
+class ModelExtraForbid(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    a: str
+
+
+class ModelExtraIgnore(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+    a: str
+
+
+class ModelExtraNone(BaseModel):
+    a: str

--- a/tests/expected_results/extra_comment/v2/output.ts
+++ b/tests/expected_results/extra_comment/v2/output.ts
@@ -1,0 +1,21 @@
+/* tslint:disable */
+/* eslint-disable */
+/**
+/* This file was automatically generated from pydantic models by running pydantic2ts.
+/* Do not modify it by hand - just update the pydantic models and then re-run the script
+/* This is a special comment
+*/
+
+export interface ModelExtraAllow {
+  a: string;
+  [k: string]: unknown;
+}
+export interface ModelExtraForbid {
+  a: string;
+}
+export interface ModelExtraIgnore {
+  a: string;
+}
+export interface ModelExtraNone {
+  a: string;
+}

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -26,7 +26,7 @@ def get_expected_output(test_name: str) -> str:
 
 
 def run_test(
-    tmpdir, test_name, *, module_path=None, call_from_python=False, exclude=()
+    tmpdir, test_name, *, module_path=None, call_from_python=False, exclude=(), extra_comment=None
 ):
     """
     Execute pydantic2ts logic for converting pydantic models into tyepscript definitions.
@@ -36,7 +36,7 @@ def run_test(
     output_path = tmpdir.join(f"cli_{test_name}.ts").strpath
 
     if call_from_python:
-        generate_typescript_defs(module_path, output_path, exclude)
+        generate_typescript_defs(module_path, output_path, exclude, extra_comment=extra_comment)
     else:
         cmd = f"pydantic2ts --module {module_path} --output {output_path}"
         for model_to_exclude in exclude:
@@ -49,7 +49,6 @@ def run_test(
     if DEBUG:
         out_dir = Path(module_path).parent
         output_path = out_dir / "output_debug.ts"
-
     assert output == get_expected_output(test_name)
 
 
@@ -163,6 +162,7 @@ def test_parse_cli_args():
     assert args_basic.output == "myOutput.ts"
     assert args_basic.exclude == []
     assert args_basic.json2ts_cmd == "json2ts"
+    assert args_basic.extra_comment == ""
     args_with_excludes = parse_cli_args(
         [
             "--module",
@@ -176,3 +176,21 @@ def test_parse_cli_args():
         ]
     )
     assert args_with_excludes.exclude == ["Foo", "Bar"]
+
+
+def test_cli_args_with_extra_comment(tmpdir):
+    args_with_comment = parse_cli_args(
+        [
+            "--module",
+            "my_module.py",
+            "--output",
+            "myOutput.ts",
+            "--extra-comment",
+            "This is a special module",
+        ]
+    )
+    assert args_with_comment.extra_comment == "This is a special module"
+
+def test_validate_extra_comments(tmpdir):
+    run_test(tmpdir, "extra_comment", call_from_python=True, extra_comment="This is a special comment")
+


### PR DESCRIPTION
It is a small change, but one that I would use immediately on a project with multiple people. I want to be able to tell people how to find and run the script that is generating the types. It could also be used to ignore additional linters / rule engines.

